### PR TITLE
Change stack profiler to only account most recent frame

### DIFF
--- a/src/net/coagulate/Core/Tools/StackTraceProfiler.java
+++ b/src/net/coagulate/Core/Tools/StackTraceProfiler.java
@@ -58,11 +58,10 @@ public class StackTraceProfiler extends Thread {
 	
 	public static void profile() {
 		for (final StackTraceElement[] stackTrace: Thread.getAllStackTraces().values()) {
-			for (final StackTraceElement stackTraceElement: stackTrace) {
-				record(stackTraceElement.getClassName(),
-				       stackTraceElement.getMethodName(),
-				       stackTraceElement.getLineNumber());
-			}
+			final StackTraceElement stackTraceElement=stackTrace[0];
+			record(stackTraceElement.getClassName(),
+			       stackTraceElement.getMethodName(),
+			       stackTraceElement.getLineNumber());
 		}
 	}
 	


### PR DESCRIPTION
otherwise you have to track down every nested call