### PR TITLE
Decache names into local fields

### DIFF
--- a/src/net/coagulate/Core/Tools/Cache.java
+++ b/src/net/coagulate/Core/Tools/Cache.java
@@ -3,6 +3,7 @@ package net.coagulate.Core.Tools;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.*;
+import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -14,9 +15,9 @@ public class Cache<U,T> {
 	 * For use during node transitions.
 	 */
 	public static        boolean                eagerCacheFlush=false;
-	private static final Map<String,Cache<?,?>> caches         =new TreeMap<>();
+	private static final Map<String,Cache<?,?>> caches         =new HashMap<>();
 	private final        int                    expiration;
-	private final Map<U,CacheElement<T>> cache=new TreeMap<>();
+	private final Map<U,CacheElement<T>> cache=new ConcurrentSkipListMap<>();
 	private long cacheHit;
 	private long cacheMiss;
 	


### PR DESCRIPTION
Resolves issue with using tree maps which need comparator which uses name which was cached which... loops